### PR TITLE
Make workload types available for eval script to use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,12 +10,12 @@ pub mod proto {
 }
 pub mod cli;
 pub mod distribution;
+pub mod workload;
 
 mod manager;
 mod units;
 pub(crate) mod util;
 mod worker;
-mod workload;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]


### PR DESCRIPTION
This commit makes workload types available for the polyphony project eval scripts to use.

Addressing issue: https://github.com/netiken/emu/issues/1
Related PR: https://github.com/kwzhao/polyphony-project/pull/26