### PR TITLE
Use TCP rather than gRPC as the data plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ cargo run --release manager --port 50000
 # Start the workers (however many you want)
 cargo run --release worker \
     --id 0 \
-    --advertise-addr 127.0.0.1:50001 \
+    --advertise-ip 127.0.0.1 \
+    --control-port 50001 \
+    --data-port 50002 \
     --manager-addr 127.0.0.1:50000 \
     --metrics-addr 0.0.0.0:9001
 cargo run --release worker \
     --id 1 \
-    --advertise-addr 127.0.0.1:50002 \
+    --advertise-ip 127.0.0.1 \
+    --control-port 50002 \
+    --data-port 50003 \
     --manager-addr 127.0.0.1:50000 \
     --metrics-addr 0.0.0.0:9002
 

--- a/examples/dscp.json
+++ b/examples/dscp.json
@@ -11,7 +11,7 @@
       },
       "target_rate": 250,
       "duration": 120,
-      "nr_connections": 2
+      "nr_workers": 2
     },
     {
       "src": 1,
@@ -24,7 +24,7 @@
       },
       "target_rate": 250,
       "duration": 120,
-      "nr_connections": 2
+      "nr_workers": 2
     }
   ],
   "size_distribution": {

--- a/examples/phasic.json
+++ b/examples/phasic.json
@@ -12,7 +12,7 @@
       "target_rate": 2000,
       "start": 0,
       "duration": 60,
-      "nr_connections": 2
+      "nr_workers": 2
     },
     {
       "src": 0,
@@ -26,7 +26,7 @@
       "target_rate": 4000,
       "start": 60,
       "duration": 60,
-      "nr_connections": 4
+      "nr_workers": 4
     }
   ],
   "size_distribution": {

--- a/examples/profile.json
+++ b/examples/profile.json
@@ -1,6 +1,6 @@
 {
   "AllToAll": {
-    "rtt": 300,
+    "rtt": 100,
     "bandwidth": 10000
   }
 }

--- a/examples/single.json
+++ b/examples/single.json
@@ -11,7 +11,7 @@
       },
       "target_rate": 2000,
       "duration": 120,
-      "nr_connections": 2
+      "nr_workers": 10
     }
   ],
   "size_distribution": {

--- a/justfile
+++ b/justfile
@@ -9,7 +9,19 @@ start-local:
     @just kill-local
     prometheus --config.file examples/prometheus.yml >/dev/null 2>&1 &
     cargo run --release manager --port 50000 >/dev/null 2>&1 &
-    cargo run --release worker --id 0 --advertise-addr 127.0.0.1:50001 --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9001 >worker0.log 2>&1 &
-    cargo run --release worker --id 1 --advertise-addr 127.0.0.1:50002 --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9002 >worker1.log 2>&1 &
-    cargo run --release worker --id 2 --advertise-addr 127.0.0.1:50003 --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9003 >worker2.log 2>&1 &
-    cargo run --release worker --id 3 --advertise-addr 127.0.0.1:50004 --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9004 >worker3.log 2>&1 &
+    cargo run --release worker --id 0 \
+        --advertise-ip 127.0.0.1 --control-port 50001 --data-port 50005 \
+        --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9001 \
+        >worker0.log 2>&1 &
+    cargo run --release worker --id 1 \
+        --advertise-ip 127.0.0.1 --control-port 50002 --data-port 50006 \
+        --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9002 \
+        >worker1.log 2>&1 &
+    cargo run --release worker --id 2 \
+        --advertise-ip 127.0.0.1 --control-port 50003 --data-port 50007 \
+        --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9003 \
+        >worker2.log 2>&1 &
+    cargo run --release worker --id 3 \
+        --advertise-ip 127.0.0.1 --control-port 50004 --data-port 50008 \
+        --manager-addr 127.0.0.1:50000 --metrics-addr 0.0.0.0:9004 \
+        >worker3.log 2>&1 &

--- a/proto/emu.proto
+++ b/proto/emu.proto
@@ -23,7 +23,8 @@ message WorkerRegistration {
 
 message WorkerAddress {
     string ip_address = 1;
-    uint32 port = 2;
+    uint32 control_port = 2;
+    uint32 data_port = 3;
 }
 
 message CheckResponse {
@@ -73,7 +74,7 @@ message P2PWorkload {
     uint32 target_rate_mbps = 5;
     uint32 start_secs = 6;
     uint32 duration_secs = 7;
-    uint32 nr_connections = 8;
+    uint32 nr_workers = 8;
 }
 
 message Ecdf {
@@ -108,8 +109,6 @@ service EmuWorker {
     rpc Stop(google.protobuf.Empty) returns (google.protobuf.Empty);
 
     rpc Ping(PingRequest) returns (PingResponse);
-
-    rpc GenericRpc(GenericRequestResponse) returns (GenericRequestResponse);
 }
 
 message WorkerAddressMap {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,7 +244,7 @@ fn init_metrics(addr: SocketAddr, buckets: &[f64]) -> anyhow::Result<()> {
 }
 
 async fn data_server(port: u16) -> anyhow::Result<()> {
-    let listener = TcpListener::bind(format!("127.0.0.1:{port}")).await?;
+    let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
     loop {
         let (mut socket, addr) = listener.accept().await?;
         tokio::spawn(async move {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,9 @@
-use std::{fs, net::SocketAddr, path::PathBuf, process};
+use std::{
+    fs,
+    net::{IpAddr, SocketAddr},
+    path::PathBuf,
+    process,
+};
 
 use crate::{
     proto::{
@@ -10,6 +15,8 @@ use crate::{
 use clap::Subcommand;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tokio::{
+    io::AsyncReadExt,
+    net::TcpListener,
     signal, task,
     time::{self, Duration},
 };
@@ -30,7 +37,13 @@ pub enum Command {
         id: WorkerId,
 
         #[arg(short, long)]
-        advertise_addr: SocketAddr,
+        advertise_ip: IpAddr,
+
+        #[arg(short, long)]
+        control_port: u16,
+
+        #[arg(short, long)]
+        data_port: u16,
 
         #[arg(short, long)]
         manager_addr: SocketAddr,
@@ -84,24 +97,29 @@ impl Command {
             }
             Command::Worker {
                 id,
-                advertise_addr,
+                advertise_ip,
+                control_port,
+                data_port,
                 manager_addr,
                 metrics_addr,
                 buckets,
             } => {
                 init_metrics(metrics_addr, &buckets)?;
-                let handle = task::spawn(async move {
+                // Start the gRPC control server.
+                let control_server = task::spawn(async move {
                     let worker = Worker::new(id);
-                    let addr = format!("0.0.0.0:{}", advertise_addr.port()).parse()?;
+                    let addr = format!("0.0.0.0:{}", control_port).parse()?;
                     Server::builder()
                         .add_service(EmuWorkerServer::new(worker))
                         .serve(addr)
                         .await?;
                     anyhow::Result::<()>::Ok(())
                 });
-                time::sleep(Duration::from_millis(10)).await; // wait for server startup
-                register_worker(id, advertise_addr, manager_addr).await?;
-                handle.await??;
+                // Start the TCP data server.
+                let data_server = task::spawn(data_server(data_port));
+                time::sleep(Duration::from_millis(10)).await; // wait for servers to startup
+                register_worker(id, advertise_ip, control_port, data_port, manager_addr).await?;
+                let (_, _) = tokio::join!(control_server, data_server);
             }
             Command::Check { manager_addr } => {
                 let nr_workers = check(manager_addr).await?;
@@ -167,13 +185,15 @@ pub async fn run(input: crate::RunInput, manager_addr: SocketAddr) -> anyhow::Re
 
 async fn register_worker(
     id: WorkerId,
-    advertise_addr: SocketAddr,
+    advertise_ip: IpAddr,
+    control_port: u16,
+    data_port: u16,
     manager_addr: SocketAddr,
 ) -> Result<(), tonic::Status> {
     const MAX_ATTEMPTS: usize = 6;
     const RETRY_DELAY: Duration = Duration::from_secs(10);
     for _ in 0..MAX_ATTEMPTS {
-        match try_register_worker(id, advertise_addr, manager_addr).await {
+        match try_register_worker(id, advertise_ip, control_port, data_port, manager_addr).await {
             Ok(_) => {
                 println!("Worker registered successfully.");
                 return Ok(());
@@ -194,15 +214,18 @@ async fn register_worker(
 
 async fn try_register_worker(
     id: WorkerId,
-    advertise_addr: SocketAddr,
+    advertise_ip: IpAddr,
+    control_port: u16,
+    data_port: u16,
     manager_addr: SocketAddr,
 ) -> Result<(), tonic::Status> {
     let mut client = EmuManagerClient::connect(format!("http://{}", manager_addr))
         .await
         .map_err(|e| Status::from_error(Box::new(e)))?;
     let address = WorkerAddress {
-        ip_address: advertise_addr.ip().to_string(),
-        port: advertise_addr.port() as u32,
+        ip_address: advertise_ip.to_string(),
+        control_port: control_port as u32,
+        data_port: data_port as u32,
     };
     let request = Request::new(WorkerRegistration {
         id: Some(id.into_inner()),
@@ -218,4 +241,26 @@ fn init_metrics(addr: SocketAddr, buckets: &[f64]) -> anyhow::Result<()> {
         .set_buckets(buckets)?
         .install()?;
     Ok(())
+}
+
+async fn data_server(port: u16) -> anyhow::Result<()> {
+    let listener = TcpListener::bind(format!("127.0.0.1:{port}")).await?;
+    loop {
+        let (mut socket, addr) = listener.accept().await?;
+        tokio::spawn(async move {
+            let mut buf = [0; 1024]; // TODO: allow bigger messages sizes
+            loop {
+                match socket.read(&mut buf).await {
+                    Ok(0) => {
+                        break;
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        eprintln!("Error on connection from {}: {}", addr, e);
+                        break;
+                    }
+                }
+            }
+        });
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,6 @@ pub enum Error {
     #[error("invalid DSCP value {0}")]
     InvalidDscp(u32),
 
-    #[error("max message size is 4MB, got {0} bytes")]
-    MaxMessageSize(usize),
-
     #[error("eCDF error: {0}")]
     Ecdf(#[from] EcdfError),
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -145,8 +145,9 @@ impl EmuWorker for Worker {
         let mut times = Vec::new();
         for _ in 0..10 {
             let mut stream = TcpStream::connect(address.data_addr()).await?;
+            let data = mk_uninit_bytes(0);
             let now = Instant::now();
-            stream.write_all(&[0; 1]).await?;
+            stream.write_all(&data).await?;
             let mut ack = [0u8; 1];
             stream.read_exact(&mut ack).await?;
             let latency = Microsecs::new(now.elapsed().as_micros() as u64);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -147,6 +147,8 @@ impl EmuWorker for Worker {
             let mut stream = TcpStream::connect(address.data_addr()).await?;
             let now = Instant::now();
             stream.write_all(&[0; 1]).await?;
+            let mut ack = [0u8; 1];
+            stream.read_exact(&mut ack).await?;
             let latency = Microsecs::new(now.elapsed().as_micros() as u64);
             times.push(latency);
             tokio::time::sleep(Duration::from_secs(1)).await;

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -9,9 +9,6 @@ use crate::{
     Error, WorkerId,
 };
 
-// gRPC limits the maximum messages size to 4MB.
-pub const SZ_GRPC_MAX: usize = 4 * 1024 * 1024;
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunInput {
     pub spec: RunSpecification,
@@ -91,14 +88,6 @@ impl TryFrom<proto::RunSpecification> for RunSpecification {
         let size_distribution = proto
             .size_distribution
             .ok_or(Error::MissingField("size_distribution"))?;
-        let &proto::CdfPoint { x: max, .. } = size_distribution
-            .points
-            .last()
-            .ok_or(Error::Ecdf(EcdfError::NoValues))?;
-        let max = max.ceil() as usize;
-        if max >= SZ_GRPC_MAX {
-            return Err(Error::MaxMessageSize(max));
-        }
         let size_distribution = Arc::new(Ecdf::try_from(size_distribution)?);
         let output_buckets = proto.output_buckets.into_iter().map(Bytes::new).collect();
         Ok(Self {

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -209,7 +209,7 @@ pub struct P2PWorkload {
     #[serde(default)]
     pub start: Secs,
     pub duration: Secs,
-    pub nr_connections: usize,
+    pub nr_workers: usize,
 }
 
 impl TryFrom<proto::P2pWorkload> for P2PWorkload {
@@ -244,7 +244,7 @@ impl TryFrom<proto::P2pWorkload> for P2PWorkload {
             target_rate,
             start,
             duration,
-            nr_connections: proto.nr_connections as usize,
+            nr_workers: proto.nr_workers as usize,
         })
     }
 }
@@ -271,7 +271,7 @@ impl From<P2PWorkload> for proto::P2pWorkload {
             start_secs: value.start.into_inner(),
             target_rate_mbps: value.target_rate.into_inner(),
             duration_secs: value.duration.into_inner(),
-            nr_connections: value.nr_connections as u32,
+            nr_workers: value.nr_workers as u32,
         }
     }
 }


### PR DESCRIPTION
A flow is now defined as a TCP connection rather than an RPC.