### PR TITLE
Fix run_duration error handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("invalid DSCP value {0}")]
     InvalidDscp(u32),
 
+    #[error("no p2p workloads specified")]
+    NoP2pWorkloads,
+
     #[error("eCDF error: {0}")]
     Ecdf(#[from] EcdfError),
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -67,12 +67,12 @@ impl RunSpecification {
 
     /// Gets the running duration of this experiment, not including the probe duration.
     pub fn run_duration(&self) -> Result<Secs, Error> {
-        Ok(self
+        self
             .p2p_workloads
             .iter()
             .map(|workload| workload.duration)
             .max()
-            .unwrap())
+            .ok_or(Error::NoP2pWorkloads)
     }
 }
 
@@ -322,6 +322,7 @@ impl From<PingResponse> for proto::PingResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn network_profile_computes_ideal_correctly() {
@@ -331,5 +332,48 @@ mod tests {
         });
         let size = Bytes::new(1_000_000_000);
         assert_eq!(profile.ideal_latency(size), Nanosecs::new(800_100_000))
+    }
+
+    #[test]
+    fn run_duration_returns_max() {
+        let ecdf = Arc::new(Ecdf::from_values(&[1.0]).unwrap());
+        let spec = RunSpecification {
+            p2p_workloads: vec![
+                P2PWorkload {
+                    src: WorkerId::new(0),
+                    dst: WorkerId::new(1),
+                    dscp: Dscp::try_new(0).unwrap(),
+                    delta_distribution_shape: DistShape::Exponential,
+                    target_rate: Mbps::new(1),
+                    start: Secs::new(0),
+                    duration: Secs::new(5),
+                    nr_workers: 1,
+                },
+                P2PWorkload {
+                    src: WorkerId::new(1),
+                    dst: WorkerId::new(0),
+                    dscp: Dscp::try_new(0).unwrap(),
+                    delta_distribution_shape: DistShape::Exponential,
+                    target_rate: Mbps::new(1),
+                    start: Secs::new(0),
+                    duration: Secs::new(10),
+                    nr_workers: 1,
+                },
+            ],
+            size_distribution: ecdf,
+            output_buckets: vec![],
+        };
+        assert_eq!(spec.run_duration().unwrap(), Secs::new(10));
+    }
+
+    #[test]
+    fn run_duration_errors_when_empty() {
+        let ecdf = Arc::new(Ecdf::from_values(&[1.0]).unwrap());
+        let spec = RunSpecification {
+            p2p_workloads: vec![],
+            size_distribution: ecdf,
+            output_buckets: vec![],
+        };
+        assert!(matches!(spec.run_duration(), Err(Error::NoP2pWorkloads)));
     }
 }


### PR DESCRIPTION
## Summary
- detect empty p2p_workloads in `run_duration`
- add `NoP2pWorkloads` error variant
- test new behaviour

## Testing
- `cargo test --quiet`